### PR TITLE
Socket.io v3 causing "Bad handshake method" , prefer v2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "muaz-khan"
   ],
   "dependencies": {
-    "socket.io": "latest"
+    "socket.io": "2.3.0"
   },
   "analyze": false,
   "license": "MIT",


### PR DESCRIPTION
Socket.io v3 causing "Bad handshake method" , prefer v2.3.0

Should really use a `package-lock.json`

v3 seems to break this for my service that used it previously with v2.3.0, the client is using v2.3.0.

Thoughts?